### PR TITLE
Modified insertion method of config secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ public/bundle.js
 
 # All NPM Debugging Logs
 npm-debug.log*
+.idea/
+app/config.js

--- a/app/api/openWeatherMap.jsx
+++ b/app/api/openWeatherMap.jsx
@@ -1,7 +1,9 @@
 const axios = require('axios');
+const config = require("../config")
 
 const OPEN_WEATHER_MAP_URL = 'http://api.openweathermap.org/data/2.5/';
 const DEFAULT_UNIT = 'imperial';
+const API_KEY = config.API_KEY
 
 module.exports = {
 	getCurrentWeather: function (location) {

--- a/app/configDefault.js
+++ b/app/configDefault.js
@@ -1,0 +1,1 @@
+export const API_KEY = "YOUR_API_KEY"

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ Want to contribute? Here's how:
 
 1. First ```fork``` and ```star``` the project.
 2. Run ```npm install``` to install all needed dependencies.
-3. Navigate to [OpenWeatherMap's ](http://openweathermap.org/) and get a free API key. Then, create a file name ```.env``` in the project root and add the following line: ```API_KEY=yourkeyhere```. This will give you access to API_KEY as a global variable anywhere in the client. It allows you to use your API Key while keeping it secret from everyone else.
+3. Navigate to [OpenWeatherMap's ](http://openweathermap.org/) and get a free API key. Then, create a file name ```config.js``` in your app folder and add the following line: ```export const API_KEY = "YOUR_API_KEY"```. This will give you access to API_KEY through the config module while keeping it hidden from everyone else.
 3. If you don't have webpack installed on your machine, run ```npm install webpack -g```.
 4. Open up two command prompts. In one, run ```webpack -w```. This lets webpack watch for changes to your files. After any saved changes, webpack automatically runs and updates your ```bundle.js``` file.
 5. In the other command prompt run ```npm start``` or ```node server.js```. These commands do the same thing: Starting your server to host the web app.


### PR DESCRIPTION
Node environment variables, injected through .env, cannot be accessed by the client. The solution is to create a config file on the client, which can be imported by other modules, that is hidden by .gitignore. 
