### PR TITLE
Add `dev` npm script task

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha app/tests/**/*.js",
-    "start": "node server.js"
+    "watch": "node node_modules/webpack/bin/webpack -w",
+    "start": "node server.js",
+    "dev": "concurrently --kill-others \"npm run watch\" \"npm start\""
   },
   "author": "Brandon Morelli",
   "license": "MIT",
@@ -34,6 +36,6 @@
     "sass-loader": "^3.1.2",
     "script-loader": "^0.6.1",
     "style-loader": "^0.13.0",
-    "webpack": "^1.12.13"
+    "webpack": "^1.13.2"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,6 @@ Want to contribute? Here's how:
 2. Run ```npm install``` to install all needed dependencies.
 3. Navigate to [OpenWeatherMap's ](http://openweathermap.org/) and get a free API key. Then, create a file name ```.env``` in the project root and add the following line: ```API_KEY=yourkeyhere```. This will give you access to API_KEY as a global variable anywhere in the client. It allows you to use your API Key while keeping it secret from everyone else.
 3. If you don't have webpack installed on your machine, run ```npm install webpack -g```.
-4. Open up two command prompts. In one, run ```webpack -w```. This lets webpack watch for changes to your files. After any saved changes, webpack automatically runs and updates your ```bundle.js``` file.
-5. In the other command prompt run ```npm start``` or ```node server.js```. These commands do the same thing: Starting your server to host the web app.
-6. Navigate to ```localhost:3000``` to see the app in action
-7. Browse the open issues, join the discussion, and push your code. All accepted Pull Requests will have their names added as contributors to the project. Thanks for all your help!
+4. Open up a command prompt and run ```npm run dev```. This will both monitor any files for changes (and rebuild the ```bundle.js``` file) and also start up a server to host the web app.
+5. Navigate to ```localhost:3000``` to see the app in action
+6. Browse the open issues, join the discussion, and push your code. All accepted Pull Requests will have their names added as contributors to the project. Thanks for all your help!


### PR DESCRIPTION
I want to lend a hand as part of Hacktoberfest and, specifically, https://github.com/bmorelli25/React-Weather-App/issues/14 but (taking a cue from some other projects I work on) know that we can run one npm script to start dev work instead of running both a webpack command (which requires webpack installed globally) and then starting the express server.

What I've done here:
- Installed the (concurrently)[https://www.npmjs.com/package/concurrently] package which means we can run two tasks at once
- Added webpack as a dev dependency so that we don't have to rely on the user having webpack installed globally
- Updated the readme with the new instructions

I know this wasn't listed as an issue specifically but it seemed like a useful thing to do ;)
