### PR TITLE
Adding settings to make sure mocha can run JSX

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "stage-0", "react"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ public/bundle.js
 
 # All NPM Debugging Logs
 npm-debug.log*
+
+# Editors
+.vscode

--- a/app/tests/setup.js
+++ b/app/tests/setup.js
@@ -1,0 +1,20 @@
+require('babel-register')();
+
+var jsdom = require('jsdom').jsdom;
+
+var exposedProperties = ['window', 'navigator', 'document'];
+
+global.document = jsdom('');
+global.window = document.defaultView;
+Object.keys(document.defaultView).forEach((property) => {
+  if (typeof global[property] === 'undefined') {
+    exposedProperties.push(property);
+    global[property] = document.defaultView[property];
+  }
+});
+
+global.navigator = {
+  userAgent: 'node.js'
+};
+
+documentRef = document;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simple React App",
   "main": "index.js",
   "scripts": {
-    "test": "mocha app/tests/**/*.js",
+    "test": "mocha -w app/tests/setup.js app/tests/**/*.spec.js",
     "start": "node server.js"
   },
   "author": "Brandon Morelli",
@@ -28,9 +28,11 @@
     "enzyme": "^2.4.1",
     "foundation-sites": "^6.2.0",
     "jquery": "^2.2.1",
+    "jsdom": "^9.6.0",
     "mocha": "^3.1.0",
     "moment": "^2.15.1",
     "node-sass": "^3.4.2",
+    "react-addons-test-utils": "^15.3.2",
     "sass-loader": "^3.1.2",
     "script-loader": "^0.6.1",
     "style-loader": "^0.13.0",


### PR DESCRIPTION
I had a few issues getting up and running with mocha and tests (as per #14 ) that need to render React components to the DOM. This should clear things up and enable other developers to start writing UI tests quicker.

Changes:
- added a `.babelrc` file which contains the presets for `babel-register`.  This file can probably be used in replace some of the babel preset settings in the webpack config file but I haven't looked into that any further
- added an exclusion to a `.vscode` folder that Visual Studio Code can add to projects. Will stop people from accidentally checking in editor specific code ;)
- added a test setup file to serve up a DOM for tests to render their react components into
- added the dev dependencies that this setup has
- changed `npm test` to run mocha via the setup js file and also only look for `.spec.js` files so that it doesn't include the test file

Keen for your thoughts on the last point there. I guess whether this is a good or bad thing depends on whether you think all tests will follow the `.spec.js` convention that's there currently
