### PR TITLE
Fixing the bind() of reactJS with GoogleAutoComplete package

### DIFF
--- a/app/components/GoogleAutocomplete.jsx
+++ b/app/components/GoogleAutocomplete.jsx
@@ -6,7 +6,7 @@ var GoogleAutocomplete = React.createClass({
 		this.autocomplete = new google.maps.places.Autocomplete(this.refs.location, {
 		  types,
 		});
-		this.autocomplete.addListener('place_changed', this.onSelected.bind(this));
+		this.autocomplete.addListener('place_changed', this.onSelected);
 	},
 
 	onSelected: function () {


### PR DESCRIPTION
React automatically binds to the component instance, so just this.onSelected is needed not this.onSelected.bind(this)

This is the error message from the Console of the Google Chrome Dev Tools :

bind(): You are binding a component method to the component. React does this for you automatically?
