### PR TITLE
Queries will show country with the city that is queried.

### DIFF
--- a/app/components/Weather.jsx
+++ b/app/components/Weather.jsx
@@ -26,7 +26,7 @@ var Weather = React.createClass({
 
     openWeatherMap.getWeather('weather', location).then(currentWeather => {
       this.setState({
-        location: currentWeather.name || location,
+        location: currentWeather.name.concat(", ",currentWeather.sys.country) || location,
         temp: currentWeather.main.temp,
         condition: currentWeather.weather[0],
         isLoading: false

--- a/app/components/Weather.jsx
+++ b/app/components/Weather.jsx
@@ -26,7 +26,7 @@ var Weather = React.createClass({
 
     openWeatherMap.getWeather('weather', location).then(currentWeather => {
       this.setState({
-        location: currentWeather.name.concat(", ",currentWeather.sys.country) || location,
+        location: {currentWeather.name + ", " + currentWeather.sys.country} || location,
         temp: currentWeather.main.temp,
         condition: currentWeather.weather[0],
         isLoading: false


### PR DESCRIPTION
If you were to look up the temperature by entering "london", then the response would not tell you what London it was checking (The one in England or the one in Ontario).

Also, if you entered a series of valid locations ("london paris berlin"), it would tell you a single temperature value, but you wouldn't be able to tell which city it comes from.

This PR should change the location that is returned to return both a city name and a country, so that the location is made clear to the user.

Please comment if you have feedback about this PR, or if you spot an error. Thanks!
